### PR TITLE
Twitter Login fixes #16

### DIFF
--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -41,3 +41,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="my-greeting/my-greeting.html">
 <link rel="import" href="my-list/my-list.html">
 <link rel="import" href="room-preview-card/room-preview-card.html">
+<link rel="import" href="twitter-login/twitter-login.html">

--- a/app/elements/twitter-login/twitter-login.html
+++ b/app/elements/twitter-login/twitter-login.html
@@ -24,41 +24,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
       }
     </style>
-    <section onclick="loginTwitter(event)">
-        
+    <section>
+        <p id="twitterRequestToken">twitter login</p>
       
-        <paper-button  data-dialog="login-modal">Login</paper-button>
-      
-        <paper-dialog id="login-modal" modal>
-          <h2>Login</h2>
-            <p>We are about to redirect you to twitter</p>
-            <div class="buttons">
-                <paper-button dialog-confirm autofocus>Cancel</paper-button>
-            </div>
-        </paper-dialog>
+
     </section>
   </template>
-  <script>
+ <script>
   (function() {
     'use strict';
- 
-    new Polymer({
-      is: 'twitter-login'
+
+    Polymer({
+      is: 'twitter-login',
+
+      properties: {
+        name: String,
+        id: Number,
+      },
+      
+        ready: function() {
+            
+         
+            
+            this.$.twitterRequestToken.addEventListener("click", twitterRequestToken);
+        
+            
+            var jwt = localStorage.getItem("jwt");
+            var socket = io('http://198.199.94.232:9000');
+            
+            socket.emit('jwt', {jwt:jwt});  
+            socket.on('jwt', function (data) {
+                localStorage.setItem("jwt", data.token);
+            });
+          
+          
+          function twitterRequestToken(){
+            socket.emit('twitterRequestToken', {jwt:jwt});  
+              console.log('fired');
+          }
+            socket.on('twitterRequestToken', function (data) {
+               window.location = data.redirectUrl;
+            });                    
+
+            
+          
+
+      }
+      
+      
     });
   })();
-  function loginTwitter(e) {
-      var button = e.target;
-      while (!button.hasAttribute('data-dialog') && button !== document.body) {
-          button = button.parentElement;
-      }
-      if (!button.hasAttribute('data-dialog')) {
-          return;
-      }
-      var id = button.getAttribute('data-dialog');
-      var dialog = document.getElementById(id);
-      if (dialog) {
-          dialog.open();
-      }
-  }
   </script>
 </dom-module>

--- a/app/elements/twitter-login/twitter-login.html
+++ b/app/elements/twitter-login/twitter-login.html
@@ -1,0 +1,64 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="/bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+
+
+
+ 
+<dom-module id="twitter-login">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <section onclick="loginTwitter(event)">
+        
+      
+        <paper-button  data-dialog="login-modal">Login</paper-button>
+      
+        <paper-dialog id="login-modal" modal>
+          <h2>Login</h2>
+            <p>We are about to redirect you to twitter</p>
+            <div class="buttons">
+                <paper-button dialog-confirm autofocus>Cancel</paper-button>
+            </div>
+        </paper-dialog>
+    </section>
+  </template>
+  <script>
+  (function() {
+    'use strict';
+ 
+    new Polymer({
+      is: 'twitter-login'
+    });
+  })();
+  function loginTwitter(e) {
+      var button = e.target;
+      while (!button.hasAttribute('data-dialog') && button !== document.body) {
+          button = button.parentElement;
+      }
+      if (!button.hasAttribute('data-dialog')) {
+          return;
+      }
+      var id = button.getAttribute('data-dialog');
+      var dialog = document.getElementById(id);
+      if (dialog) {
+          dialog.open();
+      }
+  }
+  </script>
+</dom-module>

--- a/app/elements/twitter-login/twitter-login.html
+++ b/app/elements/twitter-login/twitter-login.html
@@ -88,34 +88,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 default:
                     return 'fff';
             }
-        },        
+        },
+        listeners: {
+            'goTwitter.click': 'twitterClicked',
+        },
+        twitterClicked: function(){
+            this.socket.emit('twitterRequestToken', {jwt: this.jwt});              
+        },
       
         ready: function() {
             
-            // I want to remove this 'goTwitter' to a listener but 
-            // im not sure how to share 'socket' and 'jwt'
-            // with ready and the twitterRequestToken function
+            this.jwt = localStorage.getItem("jwt");
+            this.socket = io('http://198.199.94.232:9000');
             
-            this.$.goTwitter.addEventListener("click", twitterRequestToken);
-            
-            var jwt = localStorage.getItem("jwt");
-            var socket = io('http://198.199.94.232:9000');
-            
-            socket.emit('jwt', {jwt:jwt});  
-            socket.on('jwt', function (data) {
+            this.socket.emit('jwt', {
+                jwt: this.jwt,
+            });
+             
+            this.socket.on('jwt', function (data) {
                 localStorage.setItem("jwt", data.token);
             });
-            
-           function twitterRequestToken(){
-            socket.emit('twitterRequestToken', {jwt:jwt});  
-           }    
                       
-            socket.on('twitterRequestToken', function(data) {
+            this.socket.on('twitterRequestToken', function(data) {
                window.location = data.redirectUrl;
             });
-            
-            
-      }, // END READY
+        }, // END READY
     }); // END POLYMER
   })();
   </script>

--- a/app/elements/twitter-login/twitter-login.html
+++ b/app/elements/twitter-login/twitter-login.html
@@ -9,27 +9,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="/bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/paper-dialog/paper-dialog.html">
-<link rel="import" href="../../bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-input/paper-input.html">
 
-
-
- 
 <dom-module id="twitter-login">
   <template>
     <style>
       :host {
-        display: block;
+        display: inline-block;
+        width: 200px;
+        height: 15px;
+        cursor: hand;
+        cursor: pointer;
+       
+      }
+      .twitterbird{
+       width: 15px;
+       height: 15px;  
+       position: relative;
+       display: block;
+       float: left; 
+      }
+      .twittertext{
+       width: 0px;
+       height: 15px;  
+       display: block;
+       float: left;  
+       font-size: 14px;
+       color: white; 
+       margin: 0px;
+       padding-left: 6px;  
       }
     </style>
     <section>
-        <p id="twitterRequestToken">twitter login</p>
+        <paper-button id="goTwitter">
+        <div class="twitterbird">
+              <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.39 222.18">
+                <defs>
+                    <style>
       
-
+                    </style>
+                </defs>
+                <title>TwitterLogo_white</title>
+                <path style="fill:#{{fontColor}}" class="cls-1" d="M273.39,26.3a112.12,112.12,0,0,1-32.21,8.83,56.25,56.25,0,0,0,24.66-31,112.3,112.3,0,0,1-35.62,13.61,56.14,56.14,0,0,0-95.58,51.16A159.24,159.24,0,0,1,19,10.27,56.15,56.15,0,0,0,36.39,85.15a55.86,55.86,0,0,1-25.41-7c0,0.23,0,.47,0,0.71a56.12,56.12,0,0,0,45,55,56.23,56.23,0,0,1-25.33,1,56.15,56.15,0,0,0,52.4,39,112.54,112.54,0,0,1-69.66,24A114.17,114.17,0,0,1,0,197a158.76,158.76,0,0,0,86,25.2c103.17,0,159.58-85.47,159.58-159.59q0-3.65-.16-7.26A114,114,0,0,0,273.39,26.3Z"/>
+              </svg>
+        </div>
+        <p id="twittertext" class="twittertext">{{label}}</p>
+      </paper-button>
     </section>
   </template>
+ 
  <script>
   (function() {
     'use strict';
@@ -38,16 +66,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'twitter-login',
 
       properties: {
-        name: String,
-        id: Number,
-      },
+        label: String,
+         iconcolor:{
+           type:String,
+           value:'blue'
+         }, 
+         fontColor:{
+             type:String,
+             computed:'computeFontColor(iconcolor)'
+         },   
+       }, 
+               
+        computeFontColor: function(iconcolor) {
+          switch(iconcolor) {
+                case 'white':
+                    return 'fff';
+                    break;
+                case 'blue':
+                    return '55acee';
+                    break;
+                default:
+                    return 'fff';
+            }
+        },        
       
         ready: function() {
             
-         
+            // I want to remove this 'goTwitter' to a listener but 
+            // im not sure how to share 'socket' and 'jwt'
+            // with ready and the twitterRequestToken function
             
-            this.$.twitterRequestToken.addEventListener("click", twitterRequestToken);
-        
+            this.$.goTwitter.addEventListener("click", twitterRequestToken);
             
             var jwt = localStorage.getItem("jwt");
             var socket = io('http://198.199.94.232:9000');
@@ -56,23 +105,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             socket.on('jwt', function (data) {
                 localStorage.setItem("jwt", data.token);
             });
-          
-          
-          function twitterRequestToken(){
-            socket.emit('twitterRequestToken', {jwt:jwt});  
-              console.log('fired');
-          }
-            socket.on('twitterRequestToken', function (data) {
-               window.location = data.redirectUrl;
-            });                    
-
             
-          
-
-      }
-      
-      
-    });
+           function twitterRequestToken(){
+            socket.emit('twitterRequestToken', {jwt:jwt});  
+           }    
+                      
+            socket.on('twitterRequestToken', function(data) {
+               window.location = data.redirectUrl;
+            });
+            
+            
+      }, // END READY
+    }); // END POLYMER
   })();
   </script>
 </dom-module>

--- a/app/index.html
+++ b/app/index.html
@@ -107,8 +107,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <span class="space"></span>
 
           <!-- Toolbar icons -->
-          <paper-icon-button icon="refresh"></paper-icon-button>
-          <paper-icon-button icon="search"></paper-icon-button>
+          <twitter-login>ff</twitter-login>
+        
 
           <!-- Application name -->
           <div class="middle middle-container">

--- a/app/index.html
+++ b/app/index.html
@@ -191,7 +191,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 
   <!-- build:js scripts/app.js -->
+  <script src="scripts/socket.io-1.4.5.js"></script>
   <script src="scripts/app.js"></script>
+  
   <!-- endbuild-->
 </body>
 

--- a/app/index.html
+++ b/app/index.html
@@ -107,7 +107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <span class="space"></span>
 
           <!-- Toolbar icons -->
-          <twitter-login>ff</twitter-login>
+          <twitter-login label="login" iconcolor="white"></twitter-login>
         
 
           <!-- Application name -->


### PR DESCRIPTION
The button on the top bar, could read, "login with twitter" or use the twitter icon + the word "login" this way the user wold expect that hey going to be redirected to twitter. When they press the button we would then need to show a spinner while we ask the api for for a redirect url, then once we have the url we can redirect the user over to twitter.

or we could have a login button, when pressed asks the api to generates the redirect URL, and at the same time the user is informed via the modal that they are going to be redirect to twitter, once the redirect URL is returned we redirect them over.

The twitter url is to be generated for each visitor wishing to login, the token/url is short lived so we need to make it on demand. The request to our server results results in another request to twitter and back, this delay IMO needs a spinner or redirect message.

Using a modal allows the user, in the future to select from different oauth providers before being redirected.
